### PR TITLE
Remove extra data from storage_backend_interface

### DIFF
--- a/src/backends/api/storage_backend.h
+++ b/src/backends/api/storage_backend.h
@@ -25,14 +25,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct extra_storage_disk
-{
-    uint8_t format;
-    uint8_t development;
-    size_t offset_sys;
-    size_t offset_id;
-};
-
 struct storage_backend_interface
 {
     /* Returns a pointer to storage data
@@ -46,10 +38,6 @@ struct storage_backend_interface
     /* Notify the storage backend that data should be persisted
      */
     void (*save)(void* storage);
-
-    /* Returns a pointer to extra storage data
-     */
-    void* (*extra)(void* storage);
 };
 
 #endif

--- a/src/backends/file_storage.h
+++ b/src/backends/file_storage.h
@@ -30,13 +30,11 @@ struct file_storage
     uint8_t* data;
     size_t size;
     const char* filename;
-    void* extra;
 };
 
 int open_file_storage(struct file_storage* storage, size_t size, const char* filename);
 int open_rom_file_storage(struct file_storage* storage, const char* filename);
 void close_file_storage(struct file_storage* storage);
-int create_file_storage_extra_disk(struct file_storage* fstorage, uint8_t format, uint8_t dev, uint32_t offset_sys, uint32_t offset_id);
 
 extern const struct storage_backend_interface g_ifile_storage;
 extern const struct storage_backend_interface g_ifile_storage_ro;

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -174,9 +174,7 @@ static void write_sector(struct dd_controller* dd)
 
 static void seek_track(struct dd_controller* dd)
 {
-    struct extra_storage_disk* extra = (struct extra_storage_disk*)dd->idisk->extra(dd->disk);
-
-    if (extra->format == DISK_FORMAT_MAME)
+    if (dd->disk_format == DISK_FORMAT_MAME)
     {
         //MAME Format Seek
         static const unsigned int start_offset[] = {
@@ -212,15 +210,15 @@ static void seek_track(struct dd_controller* dd)
         if (dd->regs[DD_ASIC_CUR_SECTOR] == 0)
         {
             uint16_t block = dd->bm_track_offset / BLOCKSIZE(0);
-            uint16_t block_sys = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_sys / BLOCKSIZE(0);
-            uint16_t block_id = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_id / BLOCKSIZE(0);
+            uint16_t block_sys = dd->disk_offset_sys / BLOCKSIZE(0);
+            uint16_t block_id = dd->disk_offset_id / BLOCKSIZE(0);
             if (block < PROTECT_LBA && block != block_sys)
                 dd->regs[DD_ASIC_BM_STATUS_CTL] |= DD_BM_STATUS_MICRO;
             else if (block > PROTECT_LBA && block < (DISKID_LBA + 2) && block != block_id)
                 dd->regs[DD_ASIC_BM_STATUS_CTL] |= DD_BM_STATUS_MICRO;
         }
     }
-    else if (extra->format == DISK_FORMAT_SDK)
+    else if (dd->disk_format == DISK_FORMAT_SDK)
     {
         //SDK Format Seek
         uint16_t head = ((dd->regs[DD_ASIC_CUR_TK] & 0x1000) / 0x1000);
@@ -243,8 +241,8 @@ static void seek_track(struct dd_controller* dd)
         if (sector == 0)
         {
             uint16_t block = dd->bm_track_offset / BLOCKSIZE(0);
-            uint16_t block_sys = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_sys / BLOCKSIZE(0);
-            uint16_t block_id = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_id / BLOCKSIZE(0);
+            uint16_t block_sys = dd->disk_offset_sys / BLOCKSIZE(0);
+            uint16_t block_id = dd->disk_offset_id / BLOCKSIZE(0);
             if (block < PROTECT_LBA && block != block_sys)
                 dd->regs[DD_ASIC_BM_STATUS_CTL] |= DD_BM_STATUS_MICRO;
             else if (block > PROTECT_LBA && block < (DISKID_LBA + 2) && block != block_id)
@@ -254,10 +252,10 @@ static void seek_track(struct dd_controller* dd)
         if (lba <= MAX_LBA && sector == 0)
             DebugMessage(M64MSG_VERBOSE, "LBA %d - Offset %08X - Size %04X", lba, dd->bm_track_offset, sectorsize * SECTORS_PER_BLOCK);
     }
-    else //if (extra->format == DISK_FORMAT_D64)
+    else //if (dd->disk_format == DISK_FORMAT_D64)
     {
         //D64 Format Seek
-        struct dd_sys_data* sys_data = &dd->idisk->data(dd->disk)[D64_OFFSET_SYS];
+        const struct dd_sys_data* sys_data = (void*)(&dd->idisk->data(dd->disk)[D64_OFFSET_SYS]);
 
         uint16_t rom_lba_end = big16(sys_data->rom_lba_end);
         uint16_t ram_lba_start = big16(sys_data->ram_lba_start);
@@ -274,12 +272,12 @@ static void seek_track(struct dd_controller* dd)
         if (lba < DISKID_LBA)
         {
             //System Data
-            dd->bm_track_offset = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_sys;
+            dd->bm_track_offset = dd->disk_offset_sys;
         }
         else if ((lba >= DISKID_LBA) && (lba < SYSTEM_LBAS))
         {
             //Disk ID
-            dd->bm_track_offset = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->offset_id;
+            dd->bm_track_offset = dd->disk_offset_id;
         }
         else if (lba <= (rom_lba_end + SYSTEM_LBAS))
         {
@@ -352,7 +350,7 @@ void dd_update_bm(void* opaque)
     }
     /* handle reads (BM mode 1) */
     else {
-        uint8_t dev = ((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->development;
+        uint8_t dev = dd->disk_development;
         /* track 6 fails to read on retail units (XXX: retail test) */
         if (((dd->regs[DD_ASIC_CUR_TK] & 0x1fff) == 6) && dd->bm_block == 0 && !dev) {
             dd->regs[DD_ASIC_CMD_STATUS] &= ~DD_STATUS_DATA_RQ;
@@ -399,6 +397,7 @@ void init_dd(struct dd_controller* dd,
              void* clock, const struct clock_backend_interface* iclock,
              const uint32_t* rom, size_t rom_size,
              void* disk, const struct storage_backend_interface* idisk,
+             uint8_t disk_format, uint8_t disk_development, size_t disk_offset_sys, size_t disk_offset_id,
              struct r4300_core* r4300)
 {
     dd->rtc.clock = clock;
@@ -409,6 +408,10 @@ void init_dd(struct dd_controller* dd,
 
     dd->disk = disk;
     dd->idisk = idisk;
+    dd->disk_format = disk_format;
+    dd->disk_development = disk_development;
+    dd->disk_offset_sys = disk_offset_sys;
+    dd->disk_offset_id = disk_offset_id;
 
     GenerateLBAToPhysTable(dd);
 
@@ -435,7 +438,7 @@ void poweron_dd(struct dd_controller* dd)
     dd->regs[DD_ASIC_CMD_STATUS] |= DD_STATUS_RST_STATE;
     if (dd->idisk != NULL) {
         dd->regs[DD_ASIC_CMD_STATUS] |= DD_STATUS_DISK_PRES;
-        if (((struct extra_storage_disk*)dd->idisk->extra(dd->disk))->development)
+        if (dd->disk_development)
             dd->regs[DD_ASIC_ID_REG] = 0x00040000;
     }
 }
@@ -756,9 +759,7 @@ void dd_on_pi_cart_addr_write(struct dd_controller* dd, uint32_t address)
 void GenerateLBAToPhysTable(struct dd_controller* dd)
 {
     //For SDK and D64 formats
-    struct extra_storage_disk* extra = (struct extra_storage_disk*)dd->idisk->extra(dd->disk);
-
-    if (extra->format == DISK_FORMAT_MAME)
+    if (dd->disk_format == DISK_FORMAT_MAME)
         return;
 
     for (uint32_t lba = 0; lba < SIZE_LBA; lba++)
@@ -769,8 +770,7 @@ void GenerateLBAToPhysTable(struct dd_controller* dd)
 
 uint32_t LBAToVZone(struct dd_controller* dd, uint32_t lba)
 {
-    struct extra_storage_disk* extra = (struct extra_storage_disk*)dd->idisk->extra(dd->disk);
-    struct dd_sys_data* sys_data = dd->idisk->data(dd->disk) + extra->offset_sys;
+    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk_offset_sys);
     return LBAToVZoneA(sys_data->type, lba);
 }
 
@@ -786,8 +786,7 @@ uint32_t LBAToVZoneA(uint8_t type, uint32_t lba)
 
 uint32_t LBAToByte(struct dd_controller* dd, uint32_t lba, uint32_t nlbas)
 {
-    struct extra_storage_disk* extra = (struct extra_storage_disk*)dd->idisk->extra(dd->disk);
-    struct dd_sys_data* sys_data = dd->idisk->data(dd->disk) + extra->offset_sys;
+    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk_offset_sys);
     return LBAToByteA(sys_data->type, lba, nlbas);
 }
 
@@ -830,8 +829,7 @@ uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas)
 
 uint16_t LBAToPhys(struct dd_controller* dd, uint32_t lba)
 {
-    struct extra_storage_disk* extra = (struct extra_storage_disk*)dd->idisk->extra(dd->disk);
-    struct dd_sys_data* sys_data = dd->idisk->data(dd->disk) + extra->offset_sys;
+    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk_offset_sys);
     uint8_t disktype = sys_data->type & 0x0F;
 
     const uint16_t OUTERCYL_TBL[8] = { 0x000, 0x09E, 0x13C, 0x1D1, 0x266, 0x2FB, 0x390, 0x425 };

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -91,6 +91,10 @@ struct dd_controller
     void* disk;
     const struct storage_backend_interface* idisk;
     uint16_t lba_phys_table[0x10DC];
+    uint8_t disk_format;
+    uint8_t disk_development;
+    size_t disk_offset_sys;
+    size_t disk_offset_id;
 
     struct r4300_core* r4300;
 };
@@ -110,6 +114,7 @@ void init_dd(struct dd_controller* dd,
              void* clock, const struct clock_backend_interface* iclock,
              const uint32_t* rom, size_t rom_size,
              void* disk, const struct storage_backend_interface* idisk,
+             uint8_t disk_format, uint8_t disk_development, size_t disk_offset_sys, size_t disk_offset_id,
              struct r4300_core* r4300);
 
 void poweron_dd(struct dd_controller* dd);

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -107,7 +107,8 @@ void init_device(struct device* dev,
     /* dd */
     void* dd_rtc_clock, const struct clock_backend_interface* dd_rtc_iclock,
     size_t dd_rom_size,
-    void* dd_disk, const struct storage_backend_interface* dd_idisk)
+    void* dd_disk, const struct storage_backend_interface* dd_idisk,
+    uint8_t disk_format, uint8_t disk_development, size_t disk_offset_sys, size_t disk_offset_id)
 {
     struct interrupt_handler interrupt_handlers[] = {
         { &dev->vi,        vi_vertical_interrupt_event }, /* VI */
@@ -161,6 +162,7 @@ void init_device(struct device* dev,
                 dd_rtc_clock, dd_rtc_iclock,
                 mem_base_u32(base, MM_DD_ROM), dd_rom_size,
                 dd_disk, dd_idisk,
+                disk_format, disk_development, disk_offset_sys, disk_offset_id,
                 &dev->r4300);
     }
 

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -142,7 +142,8 @@ void init_device(struct device* dev,
     /* dd */
     void* dd_rtc_clock, const struct clock_backend_interface* dd_rtc_iclock,
     size_t dd_rom_size,
-    void* dd_disk, const struct storage_backend_interface* dd_idisk);
+    void* dd_disk, const struct storage_backend_interface* dd_idisk,
+    uint8_t disk_format, uint8_t disk_development, size_t disk_offset_sys, size_t disk_offset_id);
 
 /* Setup device such that it's state is
  * what it should be after power on.


### PR DESCRIPTION
Storage backend is only meant to abstract storage accesses, not format.
Pass all the format information as regular parameters to dd controller.