### PR TITLE
Diskupdate

### DIFF
--- a/src/backends/file_storage.h
+++ b/src/backends/file_storage.h
@@ -32,6 +32,7 @@ struct file_storage
     const char* filename;
 };
 
+
 int open_file_storage(struct file_storage* storage, size_t size, const char* filename);
 int open_rom_file_storage(struct file_storage* storage, const char* filename);
 void close_file_storage(struct file_storage* storage);

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -221,13 +221,14 @@ static void seek_track(struct dd_controller* dd)
     else if (dd->disk->format == DISK_FORMAT_SDK)
     {
         //SDK Format Seek
+        const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk->offset_sys);
         uint16_t head = ((dd->regs[DD_ASIC_CUR_TK] & 0x1000) / 0x1000);
         uint16_t track = (dd->regs[DD_ASIC_CUR_TK] & 0x0fff);
         uint16_t block = dd->bm_block;
         uint16_t sector = dd->regs[DD_ASIC_CUR_SECTOR] - dd->bm_write;
         uint16_t sectorsize = dd->regs[DD_ASIC_HOST_SECBYTE] + 1;
-        uint16_t lba = PhysToLBA(dd, head, track, block);
-        //dd->bm_zone = LBAToVZone(dd, PhysToLBA(dd, head, track, block));
+        uint16_t lba = PhysToLBA(dd->disk, head, track, block);
+        //dd->bm_zone = LBAToVZone(sys_data, PhysToLBA(dd->disk, head, track, block));
         if (lba > MAX_LBA)
         {
             dd->regs[DD_ASIC_BM_STATUS_CTL] |= DD_BM_STATUS_MICRO;
@@ -235,7 +236,7 @@ static void seek_track(struct dd_controller* dd)
             return;
         }
 
-        dd->bm_track_offset = LBAToByte(dd, 0, lba) + sector * sectorsize;
+        dd->bm_track_offset = LBAToByte(sys_data, 0, lba) + sector * sectorsize;
 
         //Handle Errors for wrong System Data
         if (sector == 0)
@@ -267,7 +268,7 @@ static void seek_track(struct dd_controller* dd)
         uint16_t block = dd->bm_block;
         uint16_t sector = dd->regs[DD_ASIC_CUR_SECTOR] - dd->bm_write;
         uint16_t sectorsize = dd->regs[DD_ASIC_HOST_SECBYTE] + 1;
-        uint16_t lba = PhysToLBA(dd, head, track, block);
+        uint16_t lba = PhysToLBA(dd->disk, head, track, block);
 
         if (lba < DISKID_LBA)
         {
@@ -408,7 +409,7 @@ void init_dd(struct dd_controller* dd,
     dd->disk = disk;
     dd->idisk = idisk;
 
-    GenerateLBAToPhysTable(dd);
+    GenerateLBAToPhysTable(disk);
 
     dd->r4300 = r4300;
 }
@@ -750,149 +751,3 @@ void dd_on_pi_cart_addr_write(struct dd_controller* dd, uint32_t address)
     }
 }
 
-/* Disk Helper routines */
-void GenerateLBAToPhysTable(struct dd_controller* dd)
-{
-    //For SDK and D64 formats
-    if (dd->disk->format == DISK_FORMAT_MAME)
-        return;
-
-    for (uint32_t lba = 0; lba < SIZE_LBA; lba++)
-    {
-        dd->disk->lba_phys_table[lba] = LBAToPhys(dd, lba);
-    }
-}
-
-uint32_t LBAToVZone(struct dd_controller* dd, uint32_t lba)
-{
-    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk->offset_sys);
-    return LBAToVZoneA(sys_data->type, lba);
-}
-
-uint32_t LBAToVZoneA(uint8_t type, uint32_t lba)
-{
-    for (uint32_t vzone = 0; vzone < 16; vzone++) {
-        if (lba < VZoneLBATable[type & 0x0F][vzone]) {
-            return vzone;
-        }
-    }
-    return -1;
-}
-
-uint32_t LBAToByte(struct dd_controller* dd, uint32_t lba, uint32_t nlbas)
-{
-    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk->offset_sys);
-    return LBAToByteA(sys_data->type, lba, nlbas);
-}
-
-uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas)
-{
-    uint8_t init_flag = 1;
-    uint32_t totalbytes = 0;
-    uint32_t blocksize = 0;
-    uint32_t vzone, pzone = 0;
-
-    uint8_t disktype = type & 0x0F;
-
-    if (nlbas != 0)
-    {
-        for (; nlbas != 0; nlbas--)
-        {
-            if ((init_flag == 1) || (VZoneLBATable[disktype][vzone] == lba))
-            {
-                vzone = LBAToVZoneA(type, lba);
-                pzone = VZoneToPZone(vzone, disktype);
-                if (7 < pzone)
-                {
-                    pzone -= 7;
-                }
-                blocksize = zone_sec_size_phys[pzone] * SECTORS_PER_BLOCK;
-            }
-
-            totalbytes += blocksize;
-            lba++;
-            init_flag = 0;
-            if (((nlbas - 1) != 0) && (lba > MAX_LBA))
-            {
-                return 0xFFFFFFFF;
-            }
-        }
-    }
-
-    return totalbytes;
-}
-
-uint16_t LBAToPhys(struct dd_controller* dd, uint32_t lba)
-{
-    const struct dd_sys_data* sys_data = (void*)(dd->idisk->data(dd->disk) + dd->disk->offset_sys);
-    uint8_t disktype = sys_data->type & 0x0F;
-
-    const uint16_t OUTERCYL_TBL[8] = { 0x000, 0x09E, 0x13C, 0x1D1, 0x266, 0x2FB, 0x390, 0x425 };
-
-    //Get Block 0/1 on Disk Track
-    uint8_t block = 1;
-    if (((lba & 3) == 0) || ((lba & 3) == 3))
-        block = 0;
-
-    //Get Virtual & Physical Disk Zones
-    uint16_t vzone = LBAToVZone(dd, lba);
-    uint16_t pzone = VZoneToPZone(vzone, disktype);
-
-    //Get Disk Head
-    uint16_t head = (7 < pzone);
-
-    //Get Disk Zone
-    uint16_t disk_zone = pzone;
-    if (disk_zone != 0)
-        disk_zone = pzone - 7;
-
-    //Get Virtual Zone LBA start, if Zone 0, it's LBA 0
-    uint16_t vzone_lba = 0;
-    if (vzone != 0)
-        vzone_lba = VZoneLBATable[disktype][vzone - 1];
-
-    //Calculate Physical Track
-    uint16_t track = (lba - vzone_lba) >> 1;
-
-    //Get the start track from current zone
-    uint16_t track_zone_start = TrackZoneTable[0][pzone];
-    if (head != 0)
-    {
-        //If Head 1, count from the other way around
-        track = -track;
-        track_zone_start = OUTERCYL_TBL[disk_zone - 1];
-    }
-    track += TrackZoneTable[0][pzone];
-
-    //Get the relative offset to defect tracks for the current zone (if Zone 0, then it's 0)
-    uint16_t defect_offset = 0;
-    if (pzone != 0)
-        defect_offset = sys_data->defect_offset[pzone - 1];
-
-    //Get amount of defect tracks for the current zone
-    uint16_t defect_amount = sys_data->defect_offset[pzone] - defect_offset;
-
-    //Skip defect tracks
-    while ((defect_amount != 0) && ((sys_data->defect_info[defect_offset] + track_zone_start) <= track))
-    {
-        track++;
-        defect_offset++;
-        defect_amount--;
-    }
-
-    return track | (head * 0x1000) | (block * 0x2000);
-}
-
-uint32_t PhysToLBA(struct dd_controller* dd, uint16_t head, uint16_t track, uint16_t block)
-{
-    uint16_t expectedvalue = track | (head * 0x1000) | (block * 0x2000);
-
-    for (uint16_t lba = 0; lba < SIZE_LBA; lba++)
-    {
-        if (dd->disk->lba_phys_table[lba] == expectedvalue)
-        {
-            return lba;
-        }
-    }
-    return 0xFFFF;
-}

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -125,13 +125,4 @@ unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, u
 void dd_on_pi_cart_addr_write(struct dd_controller* dd, uint32_t address);
 void dd_update_bm(void* opaque);
 
-/* Disk Helper routines */
-void GenerateLBAToPhysTable(struct dd_controller* dd);
-uint32_t LBAToVZone(struct dd_controller* dd, uint32_t lba);
-uint32_t LBAToVZoneA(uint8_t type, uint32_t lba);
-uint32_t LBAToByte(struct dd_controller* dd, uint32_t lba, uint32_t nlbas);
-uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas);
-uint16_t LBAToPhys(struct dd_controller* dd, uint32_t lba);
-uint32_t PhysToLBA(struct dd_controller* dd, uint16_t head, uint16_t track, uint16_t block);
-
 #endif

--- a/src/device/dd/disk.c
+++ b/src/device/dd/disk.c
@@ -51,3 +51,149 @@ const struct storage_backend_interface g_istorage_disk =
     storage_disk_size,
     storage_disk_save
 };
+
+
+/* Disk Helper routines */
+void GenerateLBAToPhysTable(struct dd_disk* disk)
+{
+    //For SDK and D64 formats
+    if (disk->format == DISK_FORMAT_MAME)
+        return;
+
+    const struct dd_sys_data* sys_data = (void*)(disk->istorage->data(disk->storage) + disk->offset_sys);
+    for (uint32_t lba = 0; lba < SIZE_LBA; lba++)
+    {
+        disk->lba_phys_table[lba] = LBAToPhys(sys_data, lba);
+    }
+}
+
+uint32_t LBAToVZone(const struct dd_sys_data* sys_data, uint32_t lba)
+{
+    return LBAToVZoneA(sys_data->type, lba);
+}
+
+uint32_t LBAToVZoneA(uint8_t type, uint32_t lba)
+{
+    for (uint32_t vzone = 0; vzone < 16; vzone++) {
+        if (lba < VZoneLBATable[type & 0x0F][vzone]) {
+            return vzone;
+        }
+    }
+    return -1;
+}
+
+uint32_t LBAToByte(const struct dd_sys_data* sys_data, uint32_t lba, uint32_t nlbas)
+{
+    return LBAToByteA(sys_data->type, lba, nlbas);
+}
+
+uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas)
+{
+    uint8_t init_flag = 1;
+    uint32_t totalbytes = 0;
+    uint32_t blocksize = 0;
+    uint32_t vzone, pzone = 0;
+
+    uint8_t disktype = type & 0x0F;
+
+    if (nlbas != 0)
+    {
+        for (; nlbas != 0; nlbas--)
+        {
+            if ((init_flag == 1) || (VZoneLBATable[disktype][vzone] == lba))
+            {
+                vzone = LBAToVZoneA(type, lba);
+                pzone = VZoneToPZone(vzone, disktype);
+                if (7 < pzone)
+                {
+                    pzone -= 7;
+                }
+                blocksize = zone_sec_size_phys[pzone] * SECTORS_PER_BLOCK;
+            }
+
+            totalbytes += blocksize;
+            lba++;
+            init_flag = 0;
+            if (((nlbas - 1) != 0) && (lba > MAX_LBA))
+            {
+                return 0xFFFFFFFF;
+            }
+        }
+    }
+
+    return totalbytes;
+}
+
+uint16_t LBAToPhys(const struct dd_sys_data* sys_data, uint32_t lba)
+{
+    uint8_t disktype = sys_data->type & 0x0F;
+
+    const uint16_t OUTERCYL_TBL[8] = { 0x000, 0x09E, 0x13C, 0x1D1, 0x266, 0x2FB, 0x390, 0x425 };
+
+    //Get Block 0/1 on Disk Track
+    uint8_t block = 1;
+    if (((lba & 3) == 0) || ((lba & 3) == 3))
+        block = 0;
+
+    //Get Virtual & Physical Disk Zones
+    uint16_t vzone = LBAToVZone(sys_data, lba);
+    uint16_t pzone = VZoneToPZone(vzone, disktype);
+
+    //Get Disk Head
+    uint16_t head = (7 < pzone);
+
+    //Get Disk Zone
+    uint16_t disk_zone = pzone;
+    if (disk_zone != 0)
+        disk_zone = pzone - 7;
+
+    //Get Virtual Zone LBA start, if Zone 0, it's LBA 0
+    uint16_t vzone_lba = 0;
+    if (vzone != 0)
+        vzone_lba = VZoneLBATable[disktype][vzone - 1];
+
+    //Calculate Physical Track
+    uint16_t track = (lba - vzone_lba) >> 1;
+
+    //Get the start track from current zone
+    uint16_t track_zone_start = TrackZoneTable[0][pzone];
+    if (head != 0)
+    {
+        //If Head 1, count from the other way around
+        track = -track;
+        track_zone_start = OUTERCYL_TBL[disk_zone - 1];
+    }
+    track += TrackZoneTable[0][pzone];
+
+    //Get the relative offset to defect tracks for the current zone (if Zone 0, then it's 0)
+    uint16_t defect_offset = 0;
+    if (pzone != 0)
+        defect_offset = sys_data->defect_offset[pzone - 1];
+
+    //Get amount of defect tracks for the current zone
+    uint16_t defect_amount = sys_data->defect_offset[pzone] - defect_offset;
+
+    //Skip defect tracks
+    while ((defect_amount != 0) && ((sys_data->defect_info[defect_offset] + track_zone_start) <= track))
+    {
+        track++;
+        defect_offset++;
+        defect_amount--;
+    }
+
+    return track | (head * 0x1000) | (block * 0x2000);
+}
+
+uint32_t PhysToLBA(const struct dd_disk* disk, uint16_t head, uint16_t track, uint16_t block)
+{
+    uint16_t expectedvalue = track | (head * 0x1000) | (block * 0x2000);
+
+    for (uint16_t lba = 0; lba < SIZE_LBA; lba++)
+    {
+        if (disk->lba_phys_table[lba] == expectedvalue)
+        {
+            return lba;
+        }
+    }
+    return 0xFFFF;
+}

--- a/src/device/dd/disk.h
+++ b/src/device/dd/disk.h
@@ -150,4 +150,13 @@ struct dd_disk
 /* Storage interface which handles the various 64DD disks format specificities */
 extern const struct storage_backend_interface g_istorage_disk;
 
+/* Disk Helper routines */
+void GenerateLBAToPhysTable(struct dd_disk* disk);
+uint32_t LBAToVZone(const struct dd_sys_data* sys_data, uint32_t lba);
+uint32_t LBAToVZoneA(uint8_t type, uint32_t lba);
+uint32_t LBAToByte(const struct dd_sys_data* sys_data, uint32_t lba, uint32_t nlbas);
+uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas);
+uint16_t LBAToPhys(const struct dd_sys_data* sys_data, uint32_t lba);
+uint32_t PhysToLBA(const struct dd_disk* disk, uint16_t head, uint16_t track, uint16_t block);
+
 #endif


### PR DESCRIPTION
Here I've moved Disk utility functions into disk module.
Also, I've changed some prototypes for const-correctness and when possible used the dd_sys_data pointer instead of dd_disk/dd pointer.

I've refrained form going much further down this refactoring because I may lack perspective and miss the point of what you want to achieve However, if it is in line with what you want please merge.
If possible also, I would like to simplify dd_controller.c:seek_track function to move what depends on the file format to disk.c and only keep in dd_controller.c:seek_track what the hardware actually does. For instance something like

```
// in dd_controller.c
seek_track(struct dd_controller* dd)
{
    // here we put only what the hardware actually perform
    error = disk_seek_track(dd->disk, ... + whatever you need const, &dd->bm_track_offset, &dd->bm_zone);
    if (error == PROTECTED_SECTOR) {
        BM_STATUS |= DD_BM_STATUS_MICRO0;
   }
}

// in dd_disk.c
disk_seek_track(whatever)
{
    if (format == D64) {
    } else if (format == SDK) {
    } else {
    }
}
```


Well that's the idea, what do you think ? Could you do it (you know better than me the diferences between the formats).
