### PR TITLE
Move seek_track logic to disk module

### DIFF
--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -562,6 +562,11 @@ unsigned int dd_dom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_ad
         cart_addr = (cart_addr - MM_DD_DS_BUFFER) & 0x3fffff;
         mem = dd->ds_buf;
     }
+    else if (cart_addr == MM_DD_MS_RAM) {
+        /* MS is not emulated, we silence warnings for now */
+        /* Recommended Count Per Op = 1, this seems to break very easily */
+        return (length * 63) / 25;
+    }
     else {
         DebugMessage(M64MSG_ERROR, "Unknown DD dma read dram=%08x  cart=%08x length=%08x",
             dram_addr, cart_addr, length);

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -523,6 +523,11 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         }
         break;
 
+    case DD_ASIC_CUR_TK: /* fallthrough */
+    case DD_ASIC_CUR_SECTOR:
+        DebugMessage(M64MSG_WARNING, "Trying to write to read-only registers: %08x <- %08x", address, value);
+        break;
+
     default:
         dd->regs[reg] = value;
     }

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -76,7 +76,6 @@ struct dd_controller
     /* buffer manager */
     unsigned char bm_write;         /* [0-1] */
     unsigned char bm_reset_held;    /* [0-1] */
-    unsigned char bm_block;         /* [0-1] */
     unsigned int bm_zone;           /* [0-15] */
 
     /* DD RTC */

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -78,7 +78,6 @@ struct dd_controller
     unsigned char bm_reset_held;    /* [0-1] */
     unsigned char bm_block;         /* [0-1] */
     unsigned int bm_zone;           /* [0-15] */
-    unsigned int bm_track_offset;   /* */
 
     /* DD RTC */
     struct dd_rtc rtc;

--- a/src/device/dd/disk.h
+++ b/src/device/dd/disk.h
@@ -160,9 +160,9 @@ uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas);
 uint16_t LBAToPhys(const struct dd_sys_data* sys_data, uint32_t lba);
 uint32_t PhysToLBA(const struct dd_disk* disk, uint16_t head, uint16_t track, uint16_t block);
 
-unsigned int disk_seek_track(const struct dd_disk* disk,
-    uint32_t cur_tk, uint32_t cur_sec, uint32_t host_secbyte,
-    unsigned char bm_write, unsigned char bm_block,
-    unsigned int* bm_zone, unsigned int* bm_track_offset);
+unsigned int get_zone_from_head_track(unsigned int head, unsigned int track);
+
+uint8_t* get_sector_base(const struct dd_disk* disk,
+    unsigned int head, unsigned int track, unsigned int block, unsigned int sector);
 
 #endif

--- a/src/device/dd/disk.h
+++ b/src/device/dd/disk.h
@@ -160,4 +160,9 @@ uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas);
 uint16_t LBAToPhys(const struct dd_sys_data* sys_data, uint32_t lba);
 uint32_t PhysToLBA(const struct dd_disk* disk, uint16_t head, uint16_t track, uint16_t block);
 
+unsigned int disk_seek_track(const struct dd_disk* disk,
+    uint32_t cur_tk, uint32_t cur_sec, uint32_t host_secbyte,
+    unsigned char bm_write, unsigned char bm_block,
+    unsigned int* bm_zone, unsigned int* bm_track_offset);
+
 #endif

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -824,7 +824,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
                 dev->dd.bm_reset_held = (unsigned char)GETDATA(curr, uint32_t);
                 dev->dd.bm_block = (unsigned char)GETDATA(curr, uint32_t);
                 dev->dd.bm_zone = GETDATA(curr, uint32_t);
-                dev->dd.bm_track_offset = GETDATA(curr, uint32_t);
+                curr += sizeof(uint32_t); /* was bm_track_offset */
             }
             else {
                 curr += (3+DD_ASIC_REGS_COUNT)*sizeof(uint32_t) + 0x100 + 0x40 + 2*sizeof(int64_t) + 2*sizeof(unsigned int);
@@ -1848,7 +1848,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         PUTDATA(curr, uint32_t, dev->dd.bm_reset_held);
         PUTDATA(curr, uint32_t, dev->dd.bm_block);
         PUTDATA(curr, uint32_t, dev->dd.bm_zone);
-        PUTDATA(curr, uint32_t, dev->dd.bm_track_offset);
+        PUTDATA(curr, uint32_t, 0); /* was bm_track_offset*/
     }
 
 #ifdef NEW_DYNAREC

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -822,7 +822,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
                 dev->dd.rtc.last_update_rtc = (time_t)GETDATA(curr, int64_t);
                 dev->dd.bm_write = (unsigned char)GETDATA(curr, uint32_t);
                 dev->dd.bm_reset_held = (unsigned char)GETDATA(curr, uint32_t);
-                dev->dd.bm_block = (unsigned char)GETDATA(curr, uint32_t);
+                curr += sizeof(uint32_t); /* was bm_block */
                 dev->dd.bm_zone = GETDATA(curr, uint32_t);
                 curr += sizeof(uint32_t); /* was bm_track_offset */
             }
@@ -1846,9 +1846,9 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         PUTDATA(curr, int64_t, (int64_t)dev->dd.rtc.last_update_rtc);
         PUTDATA(curr, uint32_t, dev->dd.bm_write);
         PUTDATA(curr, uint32_t, dev->dd.bm_reset_held);
-        PUTDATA(curr, uint32_t, dev->dd.bm_block);
+        PUTDATA(curr, uint32_t, 0); /* was bm_track_block */
         PUTDATA(curr, uint32_t, dev->dd.bm_zone);
-        PUTDATA(curr, uint32_t, 0); /* was bm_track_offset*/
+        PUTDATA(curr, uint32_t, 0); /* was bm_track_offset */
     }
 
 #ifdef NEW_DYNAREC


### PR DESCRIPTION
This is my attempt at moving seek_track logic to disk module.
I've tried to avoid too much coupling between disk and dd_controller.

I've found several places where it seems that each format has some specificities (beyond just the different track offsets) and that inhibit some more harmonizations. Is this normal or not ?

cc : @LuigiBlood 