### PR TITLE
Diskupdate

### DIFF
--- a/src/backends/file_storage.c
+++ b/src/backends/file_storage.c
@@ -103,6 +103,11 @@ static void file_storage_parent_save(void* storage)
     file_storage_save(fstorage);
 }
 
+static void dummy_save(void* storage)
+{
+    /* do nothing */
+}
+
 
 const struct storage_backend_interface g_ifile_storage =
 {
@@ -116,7 +121,7 @@ const struct storage_backend_interface g_ifile_storage_ro =
 {
     file_storage_data,
     file_storage_size,
-    NULL
+    dummy_save
 };
 
 const struct storage_backend_interface g_isubfile_storage =

--- a/src/device/dd/disk.c
+++ b/src/device/dd/disk.c
@@ -96,7 +96,8 @@ uint32_t LBAToByteA(uint8_t type, uint32_t lba, uint32_t nlbas)
     uint8_t init_flag = 1;
     uint32_t totalbytes = 0;
     uint32_t blocksize = 0;
-    uint32_t vzone, pzone = 0;
+    uint32_t vzone = 0;
+    uint32_t pzone = 0;
 
     uint8_t disktype = type & 0x0F;
 

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -291,7 +291,7 @@ static const char* strpbrk_reverse(const char* needles, const char* haystack)
 const char* namefrompath(const char* path)
 {
     const char* last_separator_ptr = strpbrk_reverse(OSAL_DIR_SEPARATORS, path);
-    
+
     if (last_separator_ptr != NULL)
         return last_separator_ptr + 1;
     else
@@ -1569,7 +1569,7 @@ void ShiftJis2UTF8(const unsigned char *pccInput, unsigned char *pucOutput, int 
             pucOutput[idxOut++] = 0x80 | (unicodeValue & 0x3f);
         }
     }
-    
+
     if (idxOut < outputLength)
         pucOutput[idxOut] = 0;
     else


### PR DESCRIPTION
Refactored a little the loading part
- use common mupen64plus save folder
- use proper extension *.ndr, *.d6r and *.ram (don't repeat .ndd, .d64 if they exists)
- I wanted to move at least some parts of the format validation to disk.c, but couldn't find a satisfying way of doing this so I didn't. I can revisit that later, it's no big deal, the complexity is contained inside a function that is not supposed to be changed everyday.

Please test and merge if it's OK for you