### PR TITLE
MAME disks can't be saved in  RAM only format, so force full save for…

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1142,6 +1142,13 @@ static void load_dd_disk(struct dd_disk* dd_disk, const struct storage_backend_i
         goto no_disk;
     }
 
+    /* Get DD Disk size */
+    size_t dd_size = 0;
+    if (get_file_size(dd_disk_filename, &dd_size) != file_ok) {
+        DebugMessage(M64MSG_ERROR, "Can't get DD disk file size");
+        goto no_disk;
+    }
+
     struct file_storage* fstorage = malloc(sizeof(struct file_storage));
     struct file_storage* fstorage_save = malloc(sizeof(struct file_storage));
     if (fstorage == NULL || fstorage_save == NULL) {
@@ -1159,7 +1166,13 @@ static void load_dd_disk(struct dd_disk* dd_disk, const struct storage_backend_i
         save_format = -1;
     }
 
-    /* Try loading *.{nd,d6}r file first (if SaveDiskFormat == 0 */
+    /* MAME disks only support full disk save */
+    if (dd_size == MAME_FORMAT_DUMP_SIZE && save_format != 0) {
+        DebugMessage(M64MSG_WARNING, "MAME disks only support full disk save format, switching to full disk format !");
+        save_format = 0;
+    }
+
+    /* Try loading *.{nd,d6}r file first (if SaveDiskFormat == 0) */
     if (save_format == 0)
     {
         if (open_rom_file_storage(fstorage, save_filename) != file_ok) {

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -180,6 +180,42 @@ close_file:
     return ret;
 }
 
+file_status_t get_file_size(const char* filename, size_t* size)
+{
+    FILE* fd;
+    int err;
+    file_status_t ret;
+
+    /* open file */
+    ret = file_open_error;
+    fd = fopen(filename, "rb");
+    if (fd == NULL)
+    {
+        return file_open_error;
+    }
+
+    /* obtain file size */
+    ret = file_size_error;
+    err = fseek(fd, 0, SEEK_END);
+    if (err != 0)
+    {
+        goto close_file;
+    }
+
+    err = ftell(fd);
+    if (err == -1)
+    {
+        goto close_file;
+    }
+
+    ret = file_ok;
+    *size = (size_t)err;
+
+    /* close file */
+close_file:
+    fclose(fd);
+    return ret;
+}
 
 /**********************
    Byte swap utilities

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -73,6 +73,12 @@ file_status_t write_chunk_to_file(const char *filename, const void *data, size_t
  */
 file_status_t load_file(const char* filename, void** buffer, size_t* size);
 
+/** get_file_size
+ *     get file size.
+ *     returns zero on success, nonzero on failure
+ */
+file_status_t get_file_size(const char* filename, size_t* size);
+
 /**********************
    Byte swap utilities
  **********************/


### PR DESCRIPTION
… them